### PR TITLE
  - Added private-message tables plus helpers for user search, sendin…

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -26,11 +26,13 @@ def create_app() -> Flask:
     from .blog import bp as blog_bp
     from .admin import bp as admin_bp
     from .tag import bp as tag_bp
+    from .messages import bp as messages_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(blog_bp)
     app.register_blueprint(admin_bp, url_prefix="/admin")
     app.register_blueprint(tag_bp, url_prefix="/tags")
+    app.register_blueprint(messages_bp)
 
     @app.before_request
     def enforce_banned_guard():
@@ -46,9 +48,13 @@ def create_app() -> Flask:
 
     @app.context_processor
     def inject_globals():
+        unread_messages = 0
+        if current_user.is_authenticated:
+            unread_messages = datastore.count_unread_messages(current_user.username, notify_only=True)
         return {
             "is_admin": getattr(current_user, "is_admin", False),
             "current_year": datetime.now().year,
+            "unread_message_count": unread_messages,
         }
 
     return app

--- a/app/messages.py
+++ b/app/messages.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from typing import Dict, List, cast
+
+from flask import Blueprint, current_app, flash, redirect, render_template, request, url_for
+from flask_login import current_user, login_required
+
+from .datastore import (
+    DataStore,
+    MESSAGE_PREFERENCES,
+    MESSAGE_PREFERENCE_DEFAULT,
+    MessagePreference,
+)
+
+
+bp = Blueprint("messages", __name__, url_prefix="/messages")
+
+_PREFERENCE_LABELS: Dict[MessagePreference, str] = {
+    "notify": "收到消息时提醒",
+    "silent": "收到消息时不提醒",
+    "block": "拉黑对方",
+}
+_PREFERENCE_ORDER: List[MessagePreference] = ["notify", "silent", "block"]
+
+
+def get_datastore() -> DataStore:
+    return current_app.extensions["datastore"]
+
+
+def _inbox_url(with_username: str | None = None) -> str:
+    if with_username:
+        return url_for("messages.inbox", **{"with": with_username})
+    return url_for("messages.inbox")
+
+
+def _display_name(record: Dict[str, object] | None, username: str) -> str:
+    if not record:
+        return username
+    real_name = str(record.get("real_name") or "").strip()
+    if real_name:
+        return f"{real_name}（{username}）"
+    return username
+
+
+def _user_brief(datastore: DataStore, username: str) -> Dict[str, object]:
+    record = datastore.get_user(username) or {}
+    return {
+        "username": username,
+        "real_name": record.get("real_name", ""),
+        "display": _display_name(record, username),
+    }
+
+
+@bp.route("/", methods=["GET"])
+@login_required
+def inbox():
+    datastore = get_datastore()
+    current_username = current_user.username
+    conversations = datastore.list_conversations(current_username)
+    selected_username = request.args.get("with", "").strip()
+    query = request.args.get("q", "").strip()
+    search_results: List[Dict[str, object]] = []
+    if query:
+        # exclude self from search results
+        search_results = [
+            {"username": item["username"], "display": _display_name(item, item["username"])}
+            for item in datastore.search_users(query, limit=20)
+            if item["username"] != current_username
+        ]
+
+    conversation_users = {item["user"] for item in conversations}
+    if selected_username:
+        conversation_users.add(selected_username)
+    user_lookup = {username: datastore.get_user(username) or {} for username in conversation_users}
+
+    enriched_conversations = []
+    for item in conversations:
+        username = item["user"]
+        enriched_conversations.append(
+            {
+                "username": username,
+                "display": _display_name(user_lookup.get(username), username),
+                "last_message": item["last_message"],
+                "unread_count": item["unread_count"],
+                "preference": item["preference"],
+            }
+        )
+
+    thread_messages: List[Dict[str, object]] = []
+    selected_user_info: Dict[str, object] | None = None
+    selected_preference: MessagePreference = MESSAGE_PREFERENCE_DEFAULT
+    if selected_username:
+        target_user = datastore.get_user(selected_username)
+        if not target_user:
+            flash("未找到目标用户", "error")
+            return redirect(_inbox_url())
+        thread_messages = [
+            {
+                **message,
+                "is_outgoing": message["sender"] == current_username,
+            }
+            for message in datastore.get_conversation_messages(current_username, selected_username)
+        ]
+        datastore.mark_conversation_read(current_username, selected_username)
+        selected_preference = datastore.get_message_preference(current_username, selected_username)
+        selected_user_info = _user_brief(datastore, selected_username)
+
+    preference_options = []
+    for value in _PREFERENCE_ORDER:
+        if value in MESSAGE_PREFERENCES:
+            preference_options.append(
+                {
+                    "value": value,
+                    "label": _PREFERENCE_LABELS[value],
+                }
+            )
+
+    return render_template(
+        "messages/inbox.html",
+        conversations=enriched_conversations,
+        selected_username=selected_username,
+        messages=thread_messages,
+        selected_user=selected_user_info,
+        selected_preference=selected_preference,
+        preference_options=sorted(preference_options, key=lambda item: item["value"]),
+        search_query=query,
+        search_results=search_results,
+    )
+
+
+@bp.route("/send", methods=["POST"])
+@login_required
+def send():
+    datastore = get_datastore()
+    recipient = (request.form.get("recipient") or "").strip()
+    content = (request.form.get("content") or "").strip()
+    if not recipient:
+        flash("请选择要发送私信的用户", "error")
+        return redirect(_inbox_url())
+    if recipient == current_user.username:
+        flash("不能给自己发送私信", "error")
+        return redirect(_inbox_url(recipient))
+    if not content:
+        flash("私信内容不能为空", "error")
+        return redirect(_inbox_url(recipient))
+    try:
+        datastore.send_private_message(current_user.username, recipient, content)
+    except PermissionError:
+        flash("对方已将你拉黑，无法发送消息", "error")
+    except ValueError as exc:
+        flash(str(exc), "error")
+    else:
+        flash("私信已发送", "success")
+    return redirect(_inbox_url(recipient))
+
+
+@bp.route("/preference/<username>", methods=["POST"])
+@login_required
+def update_preference(username: str):
+    datastore = get_datastore()
+    preference_value = (request.form.get("preference") or "").strip()
+    if preference_value not in MESSAGE_PREFERENCES:
+        flash("不支持的私信偏好", "error")
+        return redirect(_inbox_url(username))
+    try:
+        datastore.set_message_preference(
+            current_user.username,
+            username,
+            cast(MessagePreference, preference_value),
+        )
+    except ValueError as exc:
+        flash(str(exc), "error")
+    else:
+        if preference_value == MESSAGE_PREFERENCE_DEFAULT:
+            flash("已恢复默认提醒方式", "success")
+        elif preference_value == "silent":
+            flash("已设置为收到消息时不提醒", "success")
+        elif preference_value == "block":
+            flash("已拉黑该用户，后续消息将被拦截", "success")
+        else:
+            flash("已更新私信偏好", "success")
+    return redirect(_inbox_url(username))

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -108,6 +108,22 @@ body {
     transition: color 0.2s ease, background 0.2s ease;
 }
 
+.nav-links a.has-indicator {
+    position: relative;
+    padding-right: 1.25rem;
+}
+
+.nav-links .nav-indicator-dot {
+    position: absolute;
+    top: 0.45rem;
+    right: 0.4rem;
+    width: 0.5rem;
+    height: 0.5rem;
+    background: var(--danger);
+    border-radius: 50%;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9);
+}
+
 .nav-links a:hover,
 .nav-links a:focus-visible {
     color: var(--primary);
@@ -1663,6 +1679,234 @@ th {
 .profile-meta .muted-text {
     margin-bottom: 0.5rem;
     display: block;
+}
+
+.messages-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.messages-container {
+    display: flex;
+    gap: 1.5rem;
+}
+
+.messages-sidebar {
+    flex: 0 0 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    border-right: 1px solid var(--border-color);
+    padding-right: 1.25rem;
+}
+
+.messages-sidebar h3 {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--text-muted);
+}
+
+.messages-search {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.messages-search input[type="text"] {
+    flex: 1;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    padding: 0.5rem 0.75rem;
+}
+
+.messages-search-results ul,
+.messages-conversations {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.messages-conversations li a {
+    display: block;
+    padding: 0.75rem;
+    border-radius: var(--radius-sm);
+    text-decoration: none;
+    color: var(--text-color);
+    border: 1px solid transparent;
+    background: rgba(148, 163, 184, 0.08);
+    transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.messages-conversations li.is-active a {
+    border-color: var(--primary);
+    background: rgba(79, 70, 229, 0.12);
+}
+
+.messages-conversations li a:hover,
+.messages-conversations li a:focus-visible {
+    border-color: var(--primary);
+    transform: translateY(-1px);
+}
+
+.conversation-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.2rem;
+}
+
+.conversation-name {
+    font-weight: 600;
+}
+
+.conversation-unread {
+    background: var(--danger);
+    color: #fff;
+    border-radius: 999px;
+    padding: 0.1rem 0.45rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.conversation-preview {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.messages-thread {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.thread-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.thread-header h2 {
+    margin: 0 0 0.3rem;
+    font-size: 1.3rem;
+}
+
+.thread-note {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.thread-note.danger {
+    color: var(--danger-dark);
+}
+
+.thread-preference-form {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.thread-preference-form select {
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    padding: 0.4rem 0.6rem;
+}
+
+.messages-list {
+    flex: 1;
+    padding: 1rem;
+    background: rgba(148, 163, 184, 0.08);
+    border-radius: var(--radius-md);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-height: 480px;
+    overflow-y: auto;
+}
+
+.message-item {
+    max-width: min(70%, 460px);
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius-md);
+    background: var(--surface-color);
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+    position: relative;
+}
+
+.message-item.from-self {
+    margin-left: auto;
+    background: linear-gradient(135deg, var(--primary), var(--accent));
+    color: #fff;
+}
+
+.message-item.from-them {
+    margin-right: auto;
+}
+
+.message-meta {
+    font-size: 0.75rem;
+    color: var(--text-subtle);
+    margin-bottom: 0.3rem;
+}
+
+.message-item.from-self .message-meta {
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.message-body {
+    word-break: break-word;
+    line-height: 1.55;
+}
+
+.message-item.from-self .message-body {
+    color: #fff;
+}
+
+.messages-compose {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.messages-compose textarea {
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    font-size: 1rem;
+    resize: vertical;
+    min-height: 120px;
+}
+
+.messages-empty {
+    padding: 3rem 1rem;
+    text-align: center;
+    color: var(--text-muted);
+    border: 1px dashed var(--border-color);
+    border-radius: var(--radius-md);
+    background: rgba(148, 163, 184, 0.08);
+}
+
+@media (max-width: 900px) {
+    .messages-container {
+        flex-direction: column;
+    }
+
+    .messages-sidebar {
+        border-right: none;
+        border-bottom: 1px solid var(--border-color);
+        padding-right: 0;
+        padding-bottom: 1rem;
+    }
+
+    .messages-list {
+        max-height: none;
+    }
 }
 
 @media (max-width: 768px) {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,6 +21,13 @@
                 <a href="{{ url_for('tag.tree_view') }}">标签树</a>
                 {% if current_user.is_authenticated %}
                     <a href="{{ url_for('blog.create') }}">写文章</a>
+                    <a href="{{ url_for('messages.inbox') }}"
+                       class="messages-link{% if unread_message_count %} has-indicator{% endif %}">
+                        私信
+                        {% if unread_message_count %}
+                            <span class="nav-indicator-dot" aria-label="有新消息" title="有新的私信"></span>
+                        {% endif %}
+                    </a>
                     <a href="{{ url_for('blog.user_profile', username=current_user.username) }}">我的主页</a>
                     <a href="{{ url_for('blog.favorites') }}">我的收藏</a>
                     {% if current_user.is_admin %}

--- a/app/templates/blog/detail.html
+++ b/app/templates/blog/detail.html
@@ -73,7 +73,7 @@
     {% if comments %}
         <div class="comment-list">
             {% for comment in comments %}
-                <article class="comment-item">
+                <article class="comment-item" id="comment-{{ comment['id'] }}">
                     <div class="comment-meta">
                         <strong>
                             <a href="{{ url_for('blog.user_profile', username=comment['author']) }}">

--- a/app/templates/messages/inbox.html
+++ b/app/templates/messages/inbox.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+{% block title %}私信 - BNDS Blog{% endblock %}
+{% block content %}
+<div class="messages-page">
+    <div class="messages-container card">
+        <aside class="messages-sidebar">
+            <form method="get" class="messages-search">
+                <label for="message-search" class="sr-only">搜索用户名</label>
+                <input id="message-search"
+                       type="text"
+                       name="q"
+                       value="{{ search_query }}"
+                       placeholder="搜索用户名">
+                <button type="submit" class="button secondary small">搜索</button>
+            </form>
+            {% if search_query %}
+                <div class="messages-search-results">
+                    <h3>搜索结果</h3>
+                    {% if search_results %}
+                        <ul>
+                            {% for result in search_results %}
+                                <li>
+                                    <a href="{{ url_for('messages.inbox', **{'with': result['username']}) }}">
+                                        {{ result['display'] }}
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% else %}
+                        <p class="empty-state">没有找到匹配的用户。</p>
+                    {% endif %}
+                </div>
+            {% endif %}
+            <h3>最近联系人</h3>
+            {% if conversations %}
+                <ul class="messages-conversations">
+                    {% for convo in conversations %}
+                        <li class="{% if selected_username == convo['username'] %}is-active{% endif %}">
+                            <a href="{{ url_for('messages.inbox', **{'with': convo['username']}) }}">
+                                <div class="conversation-header">
+                                    <span class="conversation-name">{{ convo['display'] }}</span>
+                                    {% if convo['unread_count'] %}
+                                        <span class="conversation-unread">{{ convo['unread_count'] }}</span>
+                                    {% endif %}
+                                </div>
+                                <div class="conversation-preview">
+                                    {{ convo['last_message']['content'] | truncate(42, True) }}
+                                </div>
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <p class="empty-state">暂无私信会话，搜索用户名开始聊天。</p>
+            {% endif %}
+        </aside>
+        <section class="messages-thread">
+            {% if selected_username %}
+                <header class="thread-header">
+                    <div>
+                        <h2>{{ selected_user.display }}</h2>
+                        {% if selected_preference == 'silent' %}
+                            <p class="thread-note">当前对话设置为静默模式，新消息不会显示提醒。</p>
+                        {% elif selected_preference == 'block' %}
+                            <p class="thread-note danger">你已拉黑该用户，对方发送的消息会被拦截。</p>
+                        {% endif %}
+                    </div>
+                    <form method="post"
+                          action="{{ url_for('messages.update_preference', username=selected_username) }}"
+                          class="thread-preference-form">
+                        <label for="preference-select">提醒设置</label>
+                        <select id="preference-select" name="preference">
+                            {% for option in preference_options %}
+                                <option value="{{ option.value }}"
+                                        {% if option.value == selected_preference %}selected{% endif %}>
+                                    {{ option.label }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                        <button type="submit" class="button secondary small">保存</button>
+                    </form>
+                </header>
+                <div class="messages-list">
+                    {% if messages %}
+                        {% for message in messages %}
+                            <article class="message-item {% if message.is_outgoing %}from-self{% else %}from-them{% endif %}">
+                                <div class="message-meta">{{ message.created_at }}</div>
+                                <div class="message-body">
+                                    {{ message.content | urlize | replace('\n', '<br>') | safe }}
+                                </div>
+                            </article>
+                        {% endfor %}
+                    {% else %}
+                        <p class="empty-state">暂时没有消息，发送第一条问候吧。</p>
+                    {% endif %}
+                </div>
+                <form method="post" action="{{ url_for('messages.send') }}" class="messages-compose">
+                    <input type="hidden" name="recipient" value="{{ selected_username }}">
+                    <label for="message-content">发送新消息</label>
+                    <textarea id="message-content"
+                              name="content"
+                              rows="4"
+                              placeholder="输入你的私信内容"
+                              required></textarea>
+                    <button type="submit" class="button primary">发送</button>
+                </form>
+            {% else %}
+                <div class="messages-empty">
+                    <h2>选择联系人开始聊天</h2>
+                    <p>左侧可搜索用户名或选择已有会话。</p>
+                </div>
+            {% endif %}
+        </section>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
…g, listing, preferences, and unread counts so existing DBs migrate automatically on startup

    app/datastore.py:130, app/datastore.py:534, app/datastore.py:1002.
  - Introduced a dedicated messaging blueprint with inbox/search UI, per-contact preference controls, and unread badges app/messages.py:1, app/templates/ messages/inbox.html:1.
  - Wired the nav red-dot indicator and responsive messaging styles to surface unread notifications without spamming silent conversations app/templates/ base.html:24, app/static/style.css:103, app/static/style.css:610.
  - Comment @mentions now auto-send private message reminders with deep links, and each comment gains an anchor for direct navigation app/blog.py:139, app/ blog.py:304, app/templates/blog/detail.html:75.
  - Context processor now exposes unread_message_count for all templates so the red dot stays accurate app/__init__.py:49.